### PR TITLE
feat(email-client): add SMTP-based email client with contract abstraction

### DIFF
--- a/src/saviialib/libs/email_client/__init__.py
+++ b/src/saviialib/libs/email_client/__init__.py
@@ -1,0 +1,8 @@
+from .email_client import EmailClient
+from .types.email_client_types import EmailClientInitArgs, SendEmailArgs
+
+__all__ = [
+    "EmailClient",
+    "EmailClientInitArgs",
+    "SendEmailArgs",
+]

--- a/src/saviialib/libs/email_client/clients/__init__.py
+++ b/src/saviialib/libs/email_client/clients/__init__.py
@@ -1,0 +1,3 @@
+from .smtplib_client import SmtpLibClient
+
+__all__ = ["SmtpLibClient"]

--- a/src/saviialib/libs/email_client/clients/smtplib_client.py
+++ b/src/saviialib/libs/email_client/clients/smtplib_client.py
@@ -59,9 +59,7 @@ class SmtpLibClient(EmailClientContract):
         with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
             server.starttls()
             server.login(self.email_address, self.email_password)
-            server.sendmail(
-                self.email_address, args.recipient, message.as_string()
-            )
+            server.sendmail(self.email_address, args.recipient, message.as_string())
 
         return {
             "recipient": args.recipient,

--- a/src/saviialib/libs/email_client/clients/smtplib_client.py
+++ b/src/saviialib/libs/email_client/clients/smtplib_client.py
@@ -1,0 +1,71 @@
+import asyncio
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from saviialib.libs.email_client.email_client_contract import EmailClientContract
+from saviialib.libs.email_client.types.email_client_types import (
+    EmailClientInitArgs,
+    SendEmailArgs,
+)
+from saviialib.libs.log_client import LogClient, LogClientArgs, DebugArgs, LogStatus
+
+
+class SmtpLibClient(EmailClientContract):
+    """Concrete email client implementation using Python's smtplib."""
+
+    def __init__(self, args: EmailClientInitArgs) -> None:
+        self.email_address = args.email_address
+        self.email_password = args.email_password
+        self.smtp_server = args.smtp_server
+        self.smtp_port = args.smtp_port
+        self.logger = LogClient(
+            LogClientArgs(service_name="email_client", class_name="smtplib_client")
+        )
+
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email via SMTP using starttls and login.
+
+        :param args: SendEmailArgs with recipient, subject, body, and content_type
+        :return: dict with result metadata
+        :raises ConnectionError: if the SMTP connection or send operation fails
+        """
+        self.logger.method_name = "send_email"
+        self.logger.debug(DebugArgs(LogStatus.STARTED))
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, self._send_sync, args
+            )
+            self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
+            return result
+        except smtplib.SMTPException as error:
+            self.logger.debug(
+                DebugArgs(LogStatus.ALERT, metadata={"error": str(error)})
+            )
+            raise ConnectionError(str(error)) from error
+
+    def _send_sync(self, args: SendEmailArgs) -> dict:
+        """Perform the synchronous SMTP send operation.
+
+        :param args: SendEmailArgs
+        :return: dict with result metadata
+        """
+        message = MIMEMultipart()
+        message["From"] = self.email_address
+        message["To"] = args.recipient
+        message["Subject"] = args.subject
+        message.attach(MIMEText(args.body, args.content_type))
+
+        with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
+            server.starttls()
+            server.login(self.email_address, self.email_password)
+            server.sendmail(
+                self.email_address, args.recipient, message.as_string()
+            )
+
+        return {
+            "recipient": args.recipient,
+            "subject": args.subject,
+            "content_type": args.content_type,
+            "status": "sent",
+        }

--- a/src/saviialib/libs/email_client/email_client.py
+++ b/src/saviialib/libs/email_client/email_client.py
@@ -1,0 +1,24 @@
+from saviialib.libs.email_client.email_client_contract import EmailClientContract
+from saviialib.libs.email_client.types.email_client_types import (
+    EmailClientInitArgs,
+    SendEmailArgs,
+)
+from .clients.smtplib_client import SmtpLibClient
+
+
+class EmailClient(EmailClientContract):
+    """Main email client that delegates sending to a concrete SMTP implementation."""
+
+    # Registry of supported client names; extend here to add future implementations.
+    CLIENTS = {"smtplib_client"}
+
+    def __init__(self, args: EmailClientInitArgs) -> None:
+        self.client_obj = SmtpLibClient(args)
+
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email using the configured SMTP client.
+
+        :param args: SendEmailArgs with recipient, subject, body, and content_type
+        :return: dict with result metadata
+        """
+        return await self.client_obj.send_email(args)

--- a/src/saviialib/libs/email_client/email_client_contract.py
+++ b/src/saviialib/libs/email_client/email_client_contract.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from .types.email_client_types import SendEmailArgs
+
+
+class EmailClientContract(ABC):
+    """Abstract contract that all email client implementations must satisfy."""
+
+    @abstractmethod
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email according to the provided arguments.
+
+        :param args: SendEmailArgs containing recipient, subject, body, and content type
+        :return: dict with send result metadata
+        """
+        pass

--- a/src/saviialib/libs/email_client/types/__init__.py
+++ b/src/saviialib/libs/email_client/types/__init__.py
@@ -1,0 +1,3 @@
+from .email_client_types import EmailClientInitArgs, SendEmailArgs
+
+__all__ = ["EmailClientInitArgs", "SendEmailArgs"]

--- a/src/saviialib/libs/email_client/types/email_client_types.py
+++ b/src/saviialib/libs/email_client/types/email_client_types.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class EmailClientInitArgs:
+    """Initialization arguments for EmailClient."""
+
+    email_address: str
+    email_password: str
+    smtp_server: str = "smtp.gmail.com"
+    smtp_port: int = 587
+
+
+@dataclass
+class SendEmailArgs:
+    """Arguments for sending an email."""
+
+    recipient: str
+    subject: str
+    body: str
+    content_type: Literal["plain", "html"] = "plain"

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -1,0 +1,129 @@
+import smtplib
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs, SendEmailArgs
+from saviialib.libs.email_client.clients.smtplib_client import SmtpLibClient
+
+
+class TestSmtpLibClientSendEmail(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.init_args = EmailClientInitArgs(
+            email_address="sender@example.com",
+            email_password="secret",
+            smtp_server="smtp.gmail.com",
+            smtp_port=587,
+        )
+        self.send_args_plain = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Test Subject",
+            body="Hello, world!",
+            content_type="plain",
+        )
+        self.send_args_html = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Test Subject",
+            body="<h1>Hello</h1>",
+            content_type="html",
+        )
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_send_plain_email_successfully(self, mock_smtp_class):
+        # Arrange
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+        client = SmtpLibClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args_plain)
+
+        # Assert
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("sender@example.com", "secret")
+        mock_server.sendmail.assert_called_once()
+        self.assertEqual(result["recipient"], "recipient@example.com")
+        self.assertEqual(result["subject"], "Test Subject")
+        self.assertEqual(result["content_type"], "plain")
+        self.assertEqual(result["status"], "sent")
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_send_html_email_successfully(self, mock_smtp_class):
+        # Arrange
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+        client = SmtpLibClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args_html)
+
+        # Assert
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("sender@example.com", "secret")
+        mock_server.sendmail.assert_called_once()
+        self.assertEqual(result["content_type"], "html")
+        self.assertEqual(result["status"], "sent")
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_raise_connection_error_on_smtp_exception(
+        self, mock_smtp_class
+    ):
+        # Arrange
+        mock_smtp_class.side_effect = smtplib.SMTPException("SMTP failure")
+        client = SmtpLibClient(self.init_args)
+
+        # Act & Assert
+        with self.assertRaises(ConnectionError) as context:
+            await client.send_email(self.send_args_plain)
+        self.assertIn("SMTP failure", str(context.exception))
+
+
+class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.init_args = EmailClientInitArgs(
+            email_address="sender@example.com",
+            email_password="secret",
+        )
+        self.send_args = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Hello",
+            body="Test body",
+            content_type="plain",
+        )
+
+    @patch(
+        "saviialib.libs.email_client.email_client.SmtpLibClient.send_email",
+        new_callable=AsyncMock,
+    )
+    async def test_should_delegate_send_email_to_smtplib_client(
+        self, mock_send_email
+    ):
+        # Arrange
+        expected = {
+            "recipient": "recipient@example.com",
+            "subject": "Hello",
+            "content_type": "plain",
+            "status": "sent",
+        }
+        mock_send_email.return_value = expected
+        client = EmailClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args)
+
+        # Assert
+        mock_send_email.assert_called_once_with(self.send_args)
+        self.assertEqual(result, expected)
+
+    def test_should_use_default_smtp_server_and_port(self):
+        # Arrange
+        args = EmailClientInitArgs(
+            email_address="a@b.com",
+            email_password="pw",
+        )
+        # Act
+        client = EmailClient(args)
+        # Assert
+        self.assertEqual(client.client_obj.smtp_server, "smtp.gmail.com")
+        self.assertEqual(client.client_obj.smtp_port, 587)

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -96,9 +96,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
         "saviialib.libs.email_client.email_client.SmtpLibClient.send_email",
         new_callable=AsyncMock,
     )
-    async def test_should_delegate_send_email_to_smtplib_client(
-        self, mock_send_email
-    ):
+    async def test_should_delegate_send_email_to_smtplib_client(self, mock_send_email):
         # Arrange
         expected = {
             "recipient": "recipient@example.com",


### PR DESCRIPTION
## Changes

* Introduced `EmailClientContract`, `EmailClient`, and `SmtpLibClient` with async SMTP support.
* Added dataclass types (`EmailClientInitArgs`, `SendEmailArgs`) and exported modules via `__init__.py`.
* Added unit tests covering email sending, error handling, and configurations.

## Checklist before requesting a review

* [X] I have tested my code and it works as expected.
* [X] I have added necessary documentation (if appropriate) in the README.md.
* [X] I applied the linter with `make lint` and fixed any issues.
* [ ] I follow the conventional commits and I know that my branch should be named feat(<service>) when adding a new feature, fix(<service>) when fixing a bug, and refactor(<service>) or chore when doing maintenance work.
* [X] I know that before merging, I need pull the latest changes from the main branch and make a release version of saviia-lib with `make release`.
