### PR TITLE
feat(tasks): add email notifications for task assignments and summaries

### DIFF
--- a/src/saviialib/__init__.py
+++ b/src/saviialib/__init__.py
@@ -87,7 +87,10 @@ class SaviiaAPI:
 
             elif name == "tasks":
                 service_config = SaviiaTasksConfig(
-                    bot_token=config.bot_token, task_channel_id=config.tasks_channel_id
+                    bot_token=config.bot_token,
+                    task_channel_id=config.tasks_channel_id,
+                    email_address=config.email_address,
+                    email_password=config.email_password,
                 )
 
             self._instances[name] = api_class(service_config)

--- a/src/saviialib/general_types/api/saviia_api_types.py
+++ b/src/saviialib/general_types/api/saviia_api_types.py
@@ -34,6 +34,8 @@ class SaviiaAPIConfig:
     longitude: float = -181
     tasks_channel_id: str = ""
     bot_token: str = ""
+    email_address: str = ""
+    email_password: str = ""
 
 
 @dataclass

--- a/src/saviialib/general_types/api/saviia_tasks_api_types.py
+++ b/src/saviialib/general_types/api/saviia_tasks_api_types.py
@@ -13,3 +13,6 @@ class SaviiaTasksConfig:
 
     bot_token: str = ""
     task_channel_id: str = ""
+    email_address: str = ""
+    email_password: str = ""
+    

--- a/src/saviialib/libs/email_client/email_client.py
+++ b/src/saviialib/libs/email_client/email_client.py
@@ -10,10 +10,16 @@ class EmailClient(EmailClientContract):
     """Main email client that delegates sending to a concrete SMTP implementation."""
 
     # Registry of supported client names; extend here to add future implementations.
-    CLIENTS = {"smtplib_client"}
+    CLIENTS = {"smtplib"}
 
     def __init__(self, args: EmailClientInitArgs) -> None:
         self.client_obj = SmtpLibClient(args)
+        if args.client_name not in EmailClient.CLIENTS:
+            msg = f"Unsupported client {args.client_name}"
+            raise KeyError(msg)
+        if args.client_name == "smtplib":
+            self.client_obj = SmtpLibClient(args)
+        self.client_name = args.client_name
 
     async def send_email(self, args: SendEmailArgs) -> dict:
         """Send an email using the configured SMTP client.

--- a/src/saviialib/libs/email_client/types/email_client_types.py
+++ b/src/saviialib/libs/email_client/types/email_client_types.py
@@ -5,7 +5,7 @@ from typing import Literal
 @dataclass
 class EmailClientInitArgs:
     """Initialization arguments for EmailClient."""
-
+    client_name: Literal["smtplib"]
     email_address: str
     email_password: str
     smtp_server: str = "smtp.gmail.com"

--- a/src/saviialib/services/tasks/controllers/create_task.py
+++ b/src/saviialib/services/tasks/controllers/create_task.py
@@ -23,6 +23,7 @@ from saviialib.libs.log_client import (
     ErrorArgs,
 )
 from .validators.create_task_validator import CreateTaskValidator
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
 
 
 class CreateTaskController:
@@ -43,6 +44,15 @@ class CreateTaskController:
             )
         )
         self.validator = CreateTaskValidator(input)
+        self.email_client = EmailClient(
+            EmailClientInitArgs(
+                client_name="smtplib",
+                email_address=input.config.email_address,
+                email_password=input.config.email_password,
+                smtp_server="smtp.gmail.com",
+                smtp_port=587,
+            )
+        )
 
     async def _connect_clients(self) -> None:
         self.log_client.method_name = "_connect_clients"
@@ -82,6 +92,7 @@ class CreateTaskController:
                         images=self.input.images,
                     ),
                     notification_client=self.notification_client,
+                    email_client=self.email_client,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/controllers/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/controllers/get_pending_tasks.py
@@ -16,6 +16,7 @@ from .types.get_pending_tasks_types import (
     GetPendingTasksControllerInput,
     GetPendingTasksControllerOutput,
 )
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
 
 
 class GetPendingTasksController:
@@ -27,6 +28,15 @@ class GetPendingTasksController:
                 client_name="discord_client",
                 api_key=self.input.config.bot_token,
                 channel_id=self.input.config.task_channel_id,
+            )
+        )
+        self.email_client = EmailClient(
+            EmailClientInitArgs(
+                client_name="smtplib",
+                email_address=input.config.email_address,
+                email_password=input.config.email_password,
+                smtp_server="smtp.gmail.com",
+                smtp_port=587,
             )
         )
 
@@ -48,6 +58,7 @@ class GetPendingTasksController:
             use_case = GetPendingTasksUseCase(
                 GetPendingTasksUseCaseInput(
                     notification_client=self.notification_client,
+                    email_client=self.email_client,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -69,7 +69,7 @@ class TaskNotificationPresenter:
         return False
 
     @classmethod
-    def to_email(cls, task: dict[str, str]) -> str:
+    def task_to_email(cls, task: dict[str, str]) -> str:
         return f"""
         <html>
             <body>
@@ -90,6 +90,36 @@ class TaskNotificationPresenter:
             </body>
         </html>
         """
+
+    @classmethod
+    def tasks_to_email(cls, user: str, tasks: list[dict[str, str]]) -> str:
+        email_body = f"""
+        <html>
+            <body>
+            <h1>Hello! {user}</h1>
+            <p>Here is a summary of your pending tasks:</p>
+            <ul>
+        """
+        for task in tasks:
+            email_body += f"""
+                <li>
+                    <strong>{task.get("title")}</strong><br>
+                    Deadline: {task.get("deadline")}<br>
+                    Priority: {task.get("priority")}<br>
+                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
+                    {f"Periodicity: {task.get('periodicity')}<br>" if task.get("periodicity") else ""}
+                    {f"Category: {task.get('category')}<br>" if task.get("category") else ""}
+                </li>
+            """
+        email_body += """
+            </ul>
+            <p>Please check your task dashboard for more details and to mark the tasks as completed once done.</p>
+            <p>Regards,</p>
+            <p><strong>SAVIIA Team</strong></p>
+            </body>
+        </html>
+        """
+        return email_body
 
     @classmethod
     def to_task_notifications(

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -92,11 +92,11 @@ class TaskNotificationPresenter:
         """
 
     @classmethod
-    def tasks_to_email(cls, user: str, tasks: list[dict[str, str]]) -> str:
-        email_body = f"""
+    def tasks_to_email(cls, tasks: list[dict[str, str]]) -> str:
+        email_body = """
         <html>
             <body>
-            <h1>Hello! {user}</h1>
+            <h1>Hello!</h1>
             <p>Here is a summary of your pending tasks:</p>
             <ul>
         """
@@ -106,9 +106,8 @@ class TaskNotificationPresenter:
                     <strong>{task.get("title")}</strong><br>
                     Deadline: {task.get("deadline")}<br>
                     Priority: {task.get("priority")}<br>
-                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
                     {f"Periodicity: {task.get('periodicity')}<br>" if task.get("periodicity") else ""}
-                    {f"Category: {task.get('category')}<br>" if task.get("category") else ""}
+                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
                 </li>
             """
         email_body += """

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -69,6 +69,29 @@ class TaskNotificationPresenter:
         return False
 
     @classmethod
+    def to_email(cls, task: dict[str, str]) -> str:
+        return f"""
+        <html>
+            <body>
+            <h1>Hello {task.get("assignee", "there")}!</h1>
+            <p>You have been assigned a new task: <strong>{task.get("title")}</strong>.</p>
+            Some details about the task:
+            <ul>
+                <li><strong>Creation:</strong> {task.get("creation", "Is not mentioned.")}</li>
+                <li><strong>Deadline:</strong> {task.get("deadline")}</li>
+                <li><strong>Priority:</strong> {task.get("priority")}</li>
+                {f"<li><strong>Description:</strong> {task.get('description')}</li>" if task.get("description") else ""}
+                {f"<li><strong>Periodicity:</strong> {task.get('periodicity')}</li>" if task.get("periodicity") else ""}
+                {f"<li><strong>Category:</strong> {task.get('category')}</li>" if task.get("category") else ""}
+            </ul>
+            <p>Please check your task dashboard for more details and to mark the task as completed once
+            <p>Regards,</p>
+            <p><strong>SAVIIA Team</strong></p>
+            </body>
+        </html>
+        """
+
+    @classmethod
     def to_task_notifications(
         cls, tasks: list, params: dict = {}
     ) -> list[dict[str, str | bool | dict]]:

--- a/src/saviialib/services/tasks/use_cases/create_task.py
+++ b/src/saviialib/services/tasks/use_cases/create_task.py
@@ -11,6 +11,7 @@ from saviialib.libs.files_client import (
     WriteArgs,
 )
 from saviialib.libs.directory_client import DirectoryClient, DirectoryClientArgs
+from saviialib.libs.email_client import SendEmailArgs
 
 
 class CreateTaskUseCase:
@@ -23,6 +24,7 @@ class CreateTaskUseCase:
         self.task = input.task
         self.notification_client = input.notification_client
         self.presenter = TaskNotificationPresenter()
+        self.email_client = input.email_client
 
     async def execute(self) -> CreateTaskUseCaseOutput:
         self.logger.method_name = "execute"
@@ -48,6 +50,16 @@ class CreateTaskUseCase:
             NotifyArgs(content=content, embeds=embeds, files=files)
         )
         await self.notification_client.react(ReactArgs(new_task["id"], "📌"))
+        # Send email to the assignee if email is provided
+        if self.task.assignee_email:
+            await self.email_client.send_email(
+                SendEmailArgs(
+                    recipient=self.task.assignee_email,
+                    subject="[SAVIIA] New task assigned for you",
+                    body=self.presenter.to_email(self.task.__dict__),
+                    content_type="html",
+                )
+            )
         # Remove the tmp dir
         await self.dir_client.removedirs("tmp")
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))

--- a/src/saviialib/services/tasks/use_cases/create_task.py
+++ b/src/saviialib/services/tasks/use_cases/create_task.py
@@ -56,7 +56,7 @@ class CreateTaskUseCase:
                 SendEmailArgs(
                     recipient=self.task.assignee_email,
                     subject="[SAVIIA] New task assigned for you",
-                    body=self.presenter.to_email(self.task.__dict__),
+                    body=self.presenter.task_to_email(self.task.__dict__),
                     content_type="html",
                 )
             )

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -124,26 +124,30 @@ class GetPendingTasksUseCase:
         # First we group by user and the tasks assigned to them
         user_tasks = {}
         for task in tasks:
-            assignee = task["assignee"]
-            if assignee not in user_tasks:
-                user_tasks[assignee] = []
-            user_tasks[assignee].append(task)
-        # Then we send an email to each user with their assigned tasks
-        for user, tasks in user_tasks.items():
-            email_content = self.presenter.tasks_to_email(user, tasks)
-            if not tasks[0].get("assignee_email"):
+            assignee_email = task.get("assignee_email")
+            if not assignee_email:
+                assignee = task.get("assignee")
                 self.logger.debug(
                     DebugArgs(
                         LogStatus.EARLY_RETURN,
                         metadata={
-                            "msg": f"User {user} does not have an email address assigned. Skipping email notification."
+                            "msg": (
+                                f"Skipping email notification for {assignee}."
+                                " Does not have an email address assigned."
+                            )
                         },
                     )
                 )
                 continue
+            if assignee_email not in user_tasks:
+                user_tasks[assignee_email] = []
+            user_tasks[assignee_email].append(task)
+        # Then we send an email to each user with their assigned tasks
+        for assignee_email, tasks in user_tasks.items():
+            email_content = self.presenter.tasks_to_email(tasks)
             await self.email_client.send_email(
                 SendEmailArgs(
-                    recipient=tasks[0].get("assignee_email"),
+                    recipient=assignee_email,
                     subject="[SAVIIA] Summary of your pending tasks",
                     body=email_content,
                     content_type="html",
@@ -165,6 +169,8 @@ class GetPendingTasksUseCase:
                         "priority",
                         "periodicity",
                         "assignee",
+                        "assignee_email",
+                        "description"
                     ],
                 },
             )

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -13,6 +13,7 @@ from saviialib.libs.zero_dependency.utils.datetime_utils import (
     datetime_to_timestamp,
     str_to_datetime,
 )
+from saviialib.libs.email_client import SendEmailArgs
 
 
 class GetPendingTasksUseCase:
@@ -24,6 +25,7 @@ class GetPendingTasksUseCase:
         self.notification_client = input.notification_client
         self.date_format = "%Y-%m-%d"
         self.today = datetime_to_timestamp(today(), self.date_format)
+        self.email_client = input.email_client
 
     def _set_date_state(self, date_tmp: float):
         """If self.today > date_tmp, then the date_tmp is overdue (1). Otherwise, is on-time (0)"""
@@ -118,6 +120,36 @@ class GetPendingTasksUseCase:
             -t["priority"],  # higher numeric priority first
         )
 
+    async def _send_emails_to_assigned_users(self, tasks: list) -> None:
+        # First we group by user and the tasks assigned to them
+        user_tasks = {}
+        for task in tasks:
+            assignee = task["assignee"]
+            if assignee not in user_tasks:
+                user_tasks[assignee] = []
+            user_tasks[assignee].append(task)
+        # Then we send an email to each user with their assigned tasks
+        for user, tasks in user_tasks.items():
+            email_content = self.presenter.tasks_to_email(user, tasks)
+            if not tasks[0].get("assignee_email"):
+                self.logger.debug(
+                    DebugArgs(
+                        LogStatus.EARLY_RETURN,
+                        metadata={
+                            "msg": f"User {user} does not have an email address assigned. Skipping email notification."
+                        },
+                    )
+                )
+                continue
+            await self.email_client.send_email(
+                SendEmailArgs(
+                    recipient=tasks[0].get("assignee_email"),
+                    subject="[SAVIIA] Summary of your pending tasks",
+                    body=email_content,
+                    content_type="html",
+                )
+            )
+
     async def execute(self) -> GetPendingTasksUseCaseOutput:
         self.logger.method_name = "execute"
         self.logger.debug(DebugArgs(LogStatus.STARTED))
@@ -141,6 +173,7 @@ class GetPendingTasksUseCase:
         preprocessed_tasks = self._preprocess_tasks(uncompleted_tasks.tasks)
         sorted_tasks = sorted(preprocessed_tasks, key=self._compare_by_attr)
         overdue, ontime = self._split_task_arrays(sorted_tasks)
+        await self._send_emails_to_assigned_users(uncompleted_tasks.tasks)
 
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
         return GetPendingTasksUseCaseOutput(overdue, ontime)

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -170,7 +170,7 @@ class GetPendingTasksUseCase:
                         "periodicity",
                         "assignee",
                         "assignee_email",
-                        "description"
+                        "description",
                     ],
                 },
             )

--- a/src/saviialib/services/tasks/use_cases/types/create_task_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/create_task_types.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
 from saviialib.services.tasks.entities.task import SaviiaTask
-
+from saviialib.libs.email_client import EmailClient
 
 @dataclass
 class CreateTaskUseCaseInput:
     task: SaviiaTask
     notification_client: NotificationClient
+    email_client: EmailClient
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/types/create_task_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/create_task_types.py
@@ -3,6 +3,7 @@ from saviialib.libs.notification_client import NotificationClient
 from saviialib.services.tasks.entities.task import SaviiaTask
 from saviialib.libs.email_client import EmailClient
 
+
 @dataclass
 class CreateTaskUseCaseInput:
     task: SaviiaTask

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
+from saviialib.libs.email_client import EmailClient
 from typing import Dict, List
 
 
 @dataclass
 class GetPendingTasksUseCaseInput:
     notification_client: NotificationClient
+    email_client: EmailClient
 
 
 @dataclass

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -9,6 +9,7 @@ from saviialib.libs.email_client.clients.smtplib_client import SmtpLibClient
 class TestSmtpLibClientSendEmail(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.init_args = EmailClientInitArgs(
+            client_name="smtplib",
             email_address="sender@example.com",
             email_password="secret",
             smtp_server="smtp.gmail.com",
@@ -84,6 +85,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
         self.init_args = EmailClientInitArgs(
             email_address="sender@example.com",
             email_password="secret",
+            client_name="smtplib",
         )
         self.send_args = SendEmailArgs(
             recipient="recipient@example.com",
@@ -117,6 +119,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
     def test_should_use_default_smtp_server_and_port(self):
         # Arrange
         args = EmailClientInitArgs(
+            client_name="smtplib",
             email_address="a@b.com",
             email_password="pw",
         )


### PR DESCRIPTION
## Changes

* Added email configuration (`email_address`, `email_password`) to API and tasks configs.
* Integrated `EmailClient` (SMTP) into controllers and use cases.
* Implemented email sending in `CreateTaskUseCase` (assignments) and `GetPendingTasksUseCase` (summaries).
* Added `task_to_email` and `tasks_to_email` for HTML email formatting.
* Updated `EmailClient` initialization and types to support `smtplib`.
* Extended use case input types to include `EmailClient`.

## Checklist before requesting a review

* [X] I have tested my code and it works as expected.
* [X] I have added necessary documentation (if appropriate) in the README.md.
* [X] I applied the linter with `make lint` and fixed any issues.
* [X] I follow the conventional commits and I know that my branch should be named feat(<service>) when adding a new feature, fix(<service>) when fixing a bug, and refactor(<service>) or chore when doing maintenance work.
* [X] I know that before merging, I need pull the latest changes from the main branch and make a release version of saviia-lib with `make release`.
