### PR TITLE
feat(tasks): add email notifications, backup support, and directory touch method

### DIFF
--- a/src/saviialib/__init__.py
+++ b/src/saviialib/__init__.py
@@ -87,7 +87,10 @@ class SaviiaAPI:
 
             elif name == "tasks":
                 service_config = SaviiaTasksConfig(
-                    bot_token=config.bot_token, task_channel_id=config.tasks_channel_id
+                    bot_token=config.bot_token,
+                    task_channel_id=config.tasks_channel_id,
+                    email_address=config.email_address,
+                    email_password=config.email_password,
                 )
 
             self._instances[name] = api_class(service_config)

--- a/src/saviialib/__init__.py
+++ b/src/saviialib/__init__.py
@@ -91,6 +91,7 @@ class SaviiaAPI:
                     task_channel_id=config.tasks_channel_id,
                     email_address=config.email_address,
                     email_password=config.email_password,
+                    local_backup_path=config.local_backup_path
                 )
 
             self._instances[name] = api_class(service_config)

--- a/src/saviialib/general_types/api/saviia_api_types.py
+++ b/src/saviialib/general_types/api/saviia_api_types.py
@@ -34,6 +34,8 @@ class SaviiaAPIConfig:
     longitude: float = -181
     tasks_channel_id: str = ""
     bot_token: str = ""
+    email_address: str = ""
+    email_password: str = ""
 
 
 @dataclass

--- a/src/saviialib/general_types/api/saviia_api_types.py
+++ b/src/saviialib/general_types/api/saviia_api_types.py
@@ -30,6 +30,7 @@ class SaviiaAPIConfig:
     sharepoint_tenant_name: str
     sharepoint_site_name: str
     logger: Logger
+    local_backup_path: str
     latitude: float = -91
     longitude: float = -181
     tasks_channel_id: str = ""

--- a/src/saviialib/general_types/api/saviia_tasks_api_types.py
+++ b/src/saviialib/general_types/api/saviia_tasks_api_types.py
@@ -13,3 +13,6 @@ class SaviiaTasksConfig:
 
     bot_token: str = ""
     task_channel_id: str = ""
+    email_address: str = ""
+    email_password: str = ""
+    

--- a/src/saviialib/general_types/api/saviia_tasks_api_types.py
+++ b/src/saviialib/general_types/api/saviia_tasks_api_types.py
@@ -15,4 +15,5 @@ class SaviiaTasksConfig:
     task_channel_id: str = ""
     email_address: str = ""
     email_password: str = ""
+    local_backup_path: str = ""
     

--- a/src/saviialib/libs/directory_client/client/os_client.py
+++ b/src/saviialib/libs/directory_client/client/os_client.py
@@ -65,3 +65,11 @@ class OsClient(DirectoryClientContract):
     @staticmethod
     def get_basename(path: str):
         return os.path.basename(path)
+
+    @staticmethod
+    async def touch(path: str):
+        def _touch(path):
+            with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT), "w"):
+                pass
+            os.utime(path, None)
+        await asyncio.to_thread(_touch, path)

--- a/src/saviialib/libs/directory_client/directory_client.py
+++ b/src/saviialib/libs/directory_client/directory_client.py
@@ -30,7 +30,7 @@ class DirectoryClient(DirectoryClientContract):
 
     async def makedirs(self, path: str) -> None:
         return await self.client_obj.makedirs(path)
-    
+
     async def removedirs(self, path: str) -> None:
         return await self.client_obj.removedirs(path)
 
@@ -39,6 +39,9 @@ class DirectoryClient(DirectoryClientContract):
 
     async def walk(self, path: str) -> Iterator:
         return await self.client_obj.walk(path)
+
+    async def touch(self, path: str) -> None:
+        return await self.client_obj.touch(path)
 
     def relative_path(self, full_path: str, base_folder: str):
         return self.client_obj.relative_path(full_path, base_folder)

--- a/src/saviialib/libs/directory_client/directory_client_contract.py
+++ b/src/saviialib/libs/directory_client/directory_client_contract.py
@@ -42,3 +42,7 @@ class DirectoryClientContract(ABC):
     @abstractmethod
     def get_basename(self, path: str):
         pass
+    
+    @abstractmethod
+    async def touch(self, path: str):
+        pass

--- a/src/saviialib/libs/email_client/__init__.py
+++ b/src/saviialib/libs/email_client/__init__.py
@@ -1,0 +1,8 @@
+from .email_client import EmailClient
+from .types.email_client_types import EmailClientInitArgs, SendEmailArgs
+
+__all__ = [
+    "EmailClient",
+    "EmailClientInitArgs",
+    "SendEmailArgs",
+]

--- a/src/saviialib/libs/email_client/clients/__init__.py
+++ b/src/saviialib/libs/email_client/clients/__init__.py
@@ -1,0 +1,3 @@
+from .smtplib_client import SmtpLibClient
+
+__all__ = ["SmtpLibClient"]

--- a/src/saviialib/libs/email_client/clients/smtplib_client.py
+++ b/src/saviialib/libs/email_client/clients/smtplib_client.py
@@ -59,9 +59,7 @@ class SmtpLibClient(EmailClientContract):
         with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
             server.starttls()
             server.login(self.email_address, self.email_password)
-            server.sendmail(
-                self.email_address, args.recipient, message.as_string()
-            )
+            server.sendmail(self.email_address, args.recipient, message.as_string())
 
         return {
             "recipient": args.recipient,

--- a/src/saviialib/libs/email_client/clients/smtplib_client.py
+++ b/src/saviialib/libs/email_client/clients/smtplib_client.py
@@ -1,0 +1,71 @@
+import asyncio
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from saviialib.libs.email_client.email_client_contract import EmailClientContract
+from saviialib.libs.email_client.types.email_client_types import (
+    EmailClientInitArgs,
+    SendEmailArgs,
+)
+from saviialib.libs.log_client import LogClient, LogClientArgs, DebugArgs, LogStatus
+
+
+class SmtpLibClient(EmailClientContract):
+    """Concrete email client implementation using Python's smtplib."""
+
+    def __init__(self, args: EmailClientInitArgs) -> None:
+        self.email_address = args.email_address
+        self.email_password = args.email_password
+        self.smtp_server = args.smtp_server
+        self.smtp_port = args.smtp_port
+        self.logger = LogClient(
+            LogClientArgs(service_name="email_client", class_name="smtplib_client")
+        )
+
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email via SMTP using starttls and login.
+
+        :param args: SendEmailArgs with recipient, subject, body, and content_type
+        :return: dict with result metadata
+        :raises ConnectionError: if the SMTP connection or send operation fails
+        """
+        self.logger.method_name = "send_email"
+        self.logger.debug(DebugArgs(LogStatus.STARTED))
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, self._send_sync, args
+            )
+            self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
+            return result
+        except smtplib.SMTPException as error:
+            self.logger.debug(
+                DebugArgs(LogStatus.ALERT, metadata={"error": str(error)})
+            )
+            raise ConnectionError(str(error)) from error
+
+    def _send_sync(self, args: SendEmailArgs) -> dict:
+        """Perform the synchronous SMTP send operation.
+
+        :param args: SendEmailArgs
+        :return: dict with result metadata
+        """
+        message = MIMEMultipart()
+        message["From"] = self.email_address
+        message["To"] = args.recipient
+        message["Subject"] = args.subject
+        message.attach(MIMEText(args.body, args.content_type))
+
+        with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
+            server.starttls()
+            server.login(self.email_address, self.email_password)
+            server.sendmail(
+                self.email_address, args.recipient, message.as_string()
+            )
+
+        return {
+            "recipient": args.recipient,
+            "subject": args.subject,
+            "content_type": args.content_type,
+            "status": "sent",
+        }

--- a/src/saviialib/libs/email_client/email_client.py
+++ b/src/saviialib/libs/email_client/email_client.py
@@ -1,0 +1,24 @@
+from saviialib.libs.email_client.email_client_contract import EmailClientContract
+from saviialib.libs.email_client.types.email_client_types import (
+    EmailClientInitArgs,
+    SendEmailArgs,
+)
+from .clients.smtplib_client import SmtpLibClient
+
+
+class EmailClient(EmailClientContract):
+    """Main email client that delegates sending to a concrete SMTP implementation."""
+
+    # Registry of supported client names; extend here to add future implementations.
+    CLIENTS = {"smtplib_client"}
+
+    def __init__(self, args: EmailClientInitArgs) -> None:
+        self.client_obj = SmtpLibClient(args)
+
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email using the configured SMTP client.
+
+        :param args: SendEmailArgs with recipient, subject, body, and content_type
+        :return: dict with result metadata
+        """
+        return await self.client_obj.send_email(args)

--- a/src/saviialib/libs/email_client/email_client.py
+++ b/src/saviialib/libs/email_client/email_client.py
@@ -10,10 +10,16 @@ class EmailClient(EmailClientContract):
     """Main email client that delegates sending to a concrete SMTP implementation."""
 
     # Registry of supported client names; extend here to add future implementations.
-    CLIENTS = {"smtplib_client"}
+    CLIENTS = {"smtplib"}
 
     def __init__(self, args: EmailClientInitArgs) -> None:
         self.client_obj = SmtpLibClient(args)
+        if args.client_name not in EmailClient.CLIENTS:
+            msg = f"Unsupported client {args.client_name}"
+            raise KeyError(msg)
+        if args.client_name == "smtplib":
+            self.client_obj = SmtpLibClient(args)
+        self.client_name = args.client_name
 
     async def send_email(self, args: SendEmailArgs) -> dict:
         """Send an email using the configured SMTP client.

--- a/src/saviialib/libs/email_client/email_client_contract.py
+++ b/src/saviialib/libs/email_client/email_client_contract.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from .types.email_client_types import SendEmailArgs
+
+
+class EmailClientContract(ABC):
+    """Abstract contract that all email client implementations must satisfy."""
+
+    @abstractmethod
+    async def send_email(self, args: SendEmailArgs) -> dict:
+        """Send an email according to the provided arguments.
+
+        :param args: SendEmailArgs containing recipient, subject, body, and content type
+        :return: dict with send result metadata
+        """
+        pass

--- a/src/saviialib/libs/email_client/types/__init__.py
+++ b/src/saviialib/libs/email_client/types/__init__.py
@@ -1,0 +1,3 @@
+from .email_client_types import EmailClientInitArgs, SendEmailArgs
+
+__all__ = ["EmailClientInitArgs", "SendEmailArgs"]

--- a/src/saviialib/libs/email_client/types/email_client_types.py
+++ b/src/saviialib/libs/email_client/types/email_client_types.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class EmailClientInitArgs:
+    """Initialization arguments for EmailClient."""
+
+    email_address: str
+    email_password: str
+    smtp_server: str = "smtp.gmail.com"
+    smtp_port: int = 587
+
+
+@dataclass
+class SendEmailArgs:
+    """Arguments for sending an email."""
+
+    recipient: str
+    subject: str
+    body: str
+    content_type: Literal["plain", "html"] = "plain"

--- a/src/saviialib/libs/email_client/types/email_client_types.py
+++ b/src/saviialib/libs/email_client/types/email_client_types.py
@@ -5,7 +5,7 @@ from typing import Literal
 @dataclass
 class EmailClientInitArgs:
     """Initialization arguments for EmailClient."""
-
+    client_name: Literal["smtplib"]
     email_address: str
     email_password: str
     smtp_server: str = "smtp.gmail.com"

--- a/src/saviialib/services/tasks/api.py
+++ b/src/saviialib/services/tasks/api.py
@@ -89,7 +89,9 @@ class SaviiaTasksAPI:
         response = await controller.execute()
         return response.__dict__
 
-    async def get_pending_tasks(self, download: bool = False, notify: bool = False) -> Dict[str, Any]:
+    async def get_pending_tasks(
+        self, download: bool = False, notify: bool = False
+    ) -> Dict[str, Any]:
         """
         Retrieves pending tasks organized by deadline status and sorted by priority.
 

--- a/src/saviialib/services/tasks/api.py
+++ b/src/saviialib/services/tasks/api.py
@@ -89,7 +89,7 @@ class SaviiaTasksAPI:
         response = await controller.execute()
         return response.__dict__
 
-    async def get_pending_tasks(self) -> Dict[str, Any]:
+    async def get_pending_tasks(self, download: bool = False, notify: bool = False) -> Dict[str, Any]:
         """
         Retrieves pending tasks organized by deadline status and sorted by priority.
 
@@ -102,7 +102,7 @@ class SaviiaTasksAPI:
         :rtype: Dict[str, Any]
         """
         controller = GetPendingTasksController(
-            GetPendingTasksControllerInput(self.config)
+            GetPendingTasksControllerInput(self.config, download, notify)
         )
         response = await controller.execute()
         return response.__dict__

--- a/src/saviialib/services/tasks/controllers/create_task.py
+++ b/src/saviialib/services/tasks/controllers/create_task.py
@@ -23,6 +23,7 @@ from saviialib.libs.log_client import (
     ErrorArgs,
 )
 from .validators.create_task_validator import CreateTaskValidator
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
 
 
 class CreateTaskController:
@@ -43,6 +44,15 @@ class CreateTaskController:
             )
         )
         self.validator = CreateTaskValidator(input)
+        self.email_client = EmailClient(
+            EmailClientInitArgs(
+                client_name="smtplib",
+                email_address=input.config.email_address,
+                email_password=input.config.email_password,
+                smtp_server="smtp.gmail.com",
+                smtp_port=587,
+            )
+        )
 
     async def _connect_clients(self) -> None:
         self.log_client.method_name = "_connect_clients"
@@ -82,6 +92,7 @@ class CreateTaskController:
                         images=self.input.images,
                     ),
                     notification_client=self.notification_client,
+                    email_client=self.email_client,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/controllers/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/controllers/get_pending_tasks.py
@@ -17,6 +17,7 @@ from .types.get_pending_tasks_types import (
     GetPendingTasksControllerOutput,
 )
 from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
+from saviialib.libs.directory_client import DirectoryClient, DirectoryClientArgs
 
 
 class GetPendingTasksController:
@@ -39,6 +40,7 @@ class GetPendingTasksController:
                 smtp_port=587,
             )
         )
+        self.dir_client = DirectoryClient(DirectoryClientArgs(client_name="os_client"))
 
     async def _connect_clients(self) -> None:
         await self.notification_client.connect()
@@ -52,6 +54,8 @@ class GetPendingTasksController:
                 {
                     "bot_token": self.input.config.bot_token,
                     "task_channel_id": self.input.config.task_channel_id,
+                    "download": self.input.download,
+                    "notify": self.input.notify,
                 }
             )
             await self._connect_clients()
@@ -59,6 +63,10 @@ class GetPendingTasksController:
                 GetPendingTasksUseCaseInput(
                     notification_client=self.notification_client,
                     email_client=self.email_client,
+                    dir_client=self.dir_client,
+                    local_backup_path=self.input.config.local_backup_path,
+                    download=self.input.download,
+                    notify=self.input.notify,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/controllers/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/controllers/get_pending_tasks.py
@@ -16,6 +16,7 @@ from .types.get_pending_tasks_types import (
     GetPendingTasksControllerInput,
     GetPendingTasksControllerOutput,
 )
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
 
 
 class GetPendingTasksController:
@@ -27,6 +28,15 @@ class GetPendingTasksController:
                 client_name="discord_client",
                 api_key=self.input.config.bot_token,
                 channel_id=self.input.config.task_channel_id,
+            )
+        )
+        self.email_client = EmailClient(
+            EmailClientInitArgs(
+                client_name="smtplib",
+                email_address=input.config.email_address,
+                email_password=input.config.email_password,
+                smtp_server="smtp.gmail.com",
+                smtp_port=587,
             )
         )
 
@@ -48,6 +58,7 @@ class GetPendingTasksController:
             use_case = GetPendingTasksUseCase(
                 GetPendingTasksUseCaseInput(
                     notification_client=self.notification_client,
+                    email_client=self.email_client,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/controllers/types/get_pending_tasks_schema.py
+++ b/src/saviialib/services/tasks/controllers/types/get_pending_tasks_schema.py
@@ -5,6 +5,8 @@ GET_PENDING_TASKS_SCHEMA = {
     "properties": {
         "bot_token": {"type": "string"},
         "task_channel_id": {"type": "string"},
+        "download": {"type": "boolean"},
+        "notify": {"type": "boolean"},
     },
     "required": ["bot_token", "task_channel_id"],
     "additionalProperties": False,

--- a/src/saviialib/services/tasks/controllers/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/controllers/types/get_pending_tasks_types.py
@@ -6,6 +6,8 @@ from saviialib.general_types.api.saviia_tasks_api_types import SaviiaTasksConfig
 @dataclass
 class GetPendingTasksControllerInput:
     config: SaviiaTasksConfig
+    download: bool = False
+    notify: bool = False
 
 
 @dataclass

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -69,7 +69,7 @@ class TaskNotificationPresenter:
         return False
 
     @classmethod
-    def to_email(cls, task: dict[str, str]) -> str:
+    def task_to_email(cls, task: dict[str, str]) -> str:
         return f"""
         <html>
             <body>
@@ -90,6 +90,36 @@ class TaskNotificationPresenter:
             </body>
         </html>
         """
+
+    @classmethod
+    def tasks_to_email(cls, user: str, tasks: list[dict[str, str]]) -> str:
+        email_body = f"""
+        <html>
+            <body>
+            <h1>Hello! {user}</h1>
+            <p>Here is a summary of your pending tasks:</p>
+            <ul>
+        """
+        for task in tasks:
+            email_body += f"""
+                <li>
+                    <strong>{task.get("title")}</strong><br>
+                    Deadline: {task.get("deadline")}<br>
+                    Priority: {task.get("priority")}<br>
+                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
+                    {f"Periodicity: {task.get('periodicity')}<br>" if task.get("periodicity") else ""}
+                    {f"Category: {task.get('category')}<br>" if task.get("category") else ""}
+                </li>
+            """
+        email_body += """
+            </ul>
+            <p>Please check your task dashboard for more details and to mark the tasks as completed once done.</p>
+            <p>Regards,</p>
+            <p><strong>SAVIIA Team</strong></p>
+            </body>
+        </html>
+        """
+        return email_body
 
     @classmethod
     def to_task_notifications(

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -92,11 +92,11 @@ class TaskNotificationPresenter:
         """
 
     @classmethod
-    def tasks_to_email(cls, user: str, tasks: list[dict[str, str]]) -> str:
-        email_body = f"""
+    def tasks_to_email(cls, tasks: list[dict[str, str]]) -> str:
+        email_body = """
         <html>
             <body>
-            <h1>Hello! {user}</h1>
+            <h1>Hello!</h1>
             <p>Here is a summary of your pending tasks:</p>
             <ul>
         """
@@ -106,9 +106,8 @@ class TaskNotificationPresenter:
                     <strong>{task.get("title")}</strong><br>
                     Deadline: {task.get("deadline")}<br>
                     Priority: {task.get("priority")}<br>
-                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
                     {f"Periodicity: {task.get('periodicity')}<br>" if task.get("periodicity") else ""}
-                    {f"Category: {task.get('category')}<br>" if task.get("category") else ""}
+                    {f"Description: {task.get('description')}<br>" if task.get("description") else ""}
                 </li>
             """
         email_body += """

--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -69,6 +69,29 @@ class TaskNotificationPresenter:
         return False
 
     @classmethod
+    def to_email(cls, task: dict[str, str]) -> str:
+        return f"""
+        <html>
+            <body>
+            <h1>Hello {task.get("assignee", "there")}!</h1>
+            <p>You have been assigned a new task: <strong>{task.get("title")}</strong>.</p>
+            Some details about the task:
+            <ul>
+                <li><strong>Creation:</strong> {task.get("creation", "Is not mentioned.")}</li>
+                <li><strong>Deadline:</strong> {task.get("deadline")}</li>
+                <li><strong>Priority:</strong> {task.get("priority")}</li>
+                {f"<li><strong>Description:</strong> {task.get('description')}</li>" if task.get("description") else ""}
+                {f"<li><strong>Periodicity:</strong> {task.get('periodicity')}</li>" if task.get("periodicity") else ""}
+                {f"<li><strong>Category:</strong> {task.get('category')}</li>" if task.get("category") else ""}
+            </ul>
+            <p>Please check your task dashboard for more details and to mark the task as completed once
+            <p>Regards,</p>
+            <p><strong>SAVIIA Team</strong></p>
+            </body>
+        </html>
+        """
+
+    @classmethod
     def to_task_notifications(
         cls, tasks: list, params: dict = {}
     ) -> list[dict[str, str | bool | dict]]:

--- a/src/saviialib/services/tasks/use_cases/create_task.py
+++ b/src/saviialib/services/tasks/use_cases/create_task.py
@@ -11,6 +11,7 @@ from saviialib.libs.files_client import (
     WriteArgs,
 )
 from saviialib.libs.directory_client import DirectoryClient, DirectoryClientArgs
+from saviialib.libs.email_client import SendEmailArgs
 
 
 class CreateTaskUseCase:
@@ -23,6 +24,7 @@ class CreateTaskUseCase:
         self.task = input.task
         self.notification_client = input.notification_client
         self.presenter = TaskNotificationPresenter()
+        self.email_client = input.email_client
 
     async def execute(self) -> CreateTaskUseCaseOutput:
         self.logger.method_name = "execute"
@@ -48,6 +50,16 @@ class CreateTaskUseCase:
             NotifyArgs(content=content, embeds=embeds, files=files)
         )
         await self.notification_client.react(ReactArgs(new_task["id"], "📌"))
+        # Send email to the assignee if email is provided
+        if self.task.assignee_email:
+            await self.email_client.send_email(
+                SendEmailArgs(
+                    recipient=self.task.assignee_email,
+                    subject="[SAVIIA] New task assigned for you",
+                    body=self.presenter.to_email(self.task.__dict__),
+                    content_type="html",
+                )
+            )
         # Remove the tmp dir
         await self.dir_client.removedirs("tmp")
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))

--- a/src/saviialib/services/tasks/use_cases/create_task.py
+++ b/src/saviialib/services/tasks/use_cases/create_task.py
@@ -56,7 +56,7 @@ class CreateTaskUseCase:
                 SendEmailArgs(
                     recipient=self.task.assignee_email,
                     subject="[SAVIIA] New task assigned for you",
-                    body=self.presenter.to_email(self.task.__dict__),
+                    body=self.presenter.task_to_email(self.task.__dict__),
                     content_type="html",
                 )
             )

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -12,11 +12,15 @@ from saviialib.libs.zero_dependency.utils.datetime_utils import (
     today,
     datetime_to_timestamp,
     str_to_datetime,
+    datetime_to_str,
 )
+import pandas as pd
 from saviialib.libs.email_client import SendEmailArgs
 
 
 class GetPendingTasksUseCase:
+    TASKS_DIRNAME = "saviia-tasks"
+
     def __init__(self, input: GetPendingTasksUseCaseInput) -> None:
         self.logger = LogClient(
             LogClientArgs(service_name="tasks", class_name="get_pending_tasks")
@@ -26,6 +30,10 @@ class GetPendingTasksUseCase:
         self.date_format = "%Y-%m-%d"
         self.today = datetime_to_timestamp(today(), self.date_format)
         self.email_client = input.email_client
+        self.local_backup_path = input.local_backup_path
+        self.dir_client = input.dir_client
+        self.download = input.download
+        self.notify = input.notify
 
     def _set_date_state(self, date_tmp: float):
         """If self.today > date_tmp, then the date_tmp is overdue (1). Otherwise, is on-time (0)"""
@@ -65,9 +73,13 @@ class GetPendingTasksUseCase:
             map(
                 lambda t: {
                     "title": t["title"],
+                    "creation": t.get("creation", ""),
                     "deadline": t["deadline"],
+                    "execution": t.get("execution", ""),
+                    "description": t.get("description", ""),
                     "priority": int(t["priority"]),
                     "assignee": t["assignee"],
+                    "assignee_email": t.get("assignee_email", ""),
                     "deadline_categ": self._set_date_state(
                         datetime_to_timestamp(
                             str_to_datetime(t["deadline"], self.date_format),
@@ -154,10 +166,46 @@ class GetPendingTasksUseCase:
                 )
             )
 
+    async def _save_tasks(self, tasks: list[dict[str, str | bool | dict]]) -> None:
+        self.logger.method_name = "_save_tasks"
+        self.logger.debug(DebugArgs(LogStatus.STARTED))
+        if not await self.dir_client.path_exists(self.local_backup_path):
+            self.logger.debug(
+                DebugArgs(
+                    LogStatus.EARLY_RETURN,
+                    metadata={
+                        "msg": f"The directory {self.local_backup_path} doesn't exist."
+                    },
+                )
+            )
+            return
+        # First time access
+        tasks_dir = self.dir_client.join_paths(
+            self.local_backup_path, self.TASKS_DIRNAME
+        )
+        if not await self.dir_client.path_exists(tasks_dir):
+            self.logger.debug(
+                DebugArgs(
+                    LogStatus.ALERT,
+                    metadata={
+                        "msg": f"The directory {self.TASKS_DIRNAME} doesn't exist. Creating..."
+                    },
+                )
+            )
+            await self.dir_client.makedirs(tasks_dir)
+            pass_file_path = self.dir_client.join_paths(tasks_dir, ".PASS.txt")
+            await self.dir_client.touch(pass_file_path)
+        filename = datetime_to_str(today(), date_format="%Y%m%d") + "_tasks.xlsx"
+        df = pd.DataFrame(tasks)
+        df = df.drop(columns=["assignee_email", "periodicity_freq", "periodicity_categ", "deadline_categ"])
+        excel_file_path = self.dir_client.join_paths(tasks_dir, filename)
+        df.to_excel(excel_file_path, index=False)
+        self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
+        self.logger.method_name = "execute"
+
     async def execute(self) -> GetPendingTasksUseCaseOutput:
         self.logger.method_name = "execute"
         self.logger.debug(DebugArgs(LogStatus.STARTED))
-
         uncompleted_tasks = await GetTasksUseCase(
             GetTasksUseCaseInput(
                 self.notification_client,
@@ -165,7 +213,9 @@ class GetPendingTasksUseCase:
                     "completed": False,
                     "fields": [
                         "title",
+                        "creation",
                         "deadline",
+                        "execution",
                         "priority",
                         "periodicity",
                         "assignee",
@@ -175,11 +225,22 @@ class GetPendingTasksUseCase:
                 },
             )
         ).execute()
-
         preprocessed_tasks = self._preprocess_tasks(uncompleted_tasks.tasks)
         sorted_tasks = sorted(preprocessed_tasks, key=self._compare_by_attr)
         overdue, ontime = self._split_task_arrays(sorted_tasks)
-        await self._send_emails_to_assigned_users(uncompleted_tasks.tasks)
+        self.logger.debug(
+            DebugArgs(LogStatus.ALERT, {"msg": f"send email?: {self.notify}"})
+        )
+        if self.notify:
+            await self._send_emails_to_assigned_users(sorted_tasks)
+        self.logger.debug(
+            DebugArgs(
+                LogStatus.ALERT,
+                {"msg": f"download not completed tasks?: {self.download}"},
+            )
+        )
+        if self.download:
+            await self._save_tasks(sorted_tasks)
 
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
         return GetPendingTasksUseCaseOutput(overdue, ontime)

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -124,26 +124,30 @@ class GetPendingTasksUseCase:
         # First we group by user and the tasks assigned to them
         user_tasks = {}
         for task in tasks:
-            assignee = task["assignee"]
-            if assignee not in user_tasks:
-                user_tasks[assignee] = []
-            user_tasks[assignee].append(task)
-        # Then we send an email to each user with their assigned tasks
-        for user, tasks in user_tasks.items():
-            email_content = self.presenter.tasks_to_email(user, tasks)
-            if not tasks[0].get("assignee_email"):
+            assignee_email = task.get("assignee_email")
+            if not assignee_email:
+                assignee = task.get("assignee")
                 self.logger.debug(
                     DebugArgs(
                         LogStatus.EARLY_RETURN,
                         metadata={
-                            "msg": f"User {user} does not have an email address assigned. Skipping email notification."
+                            "msg": (
+                                f"Skipping email notification for {assignee}."
+                                " Does not have an email address assigned."
+                            )
                         },
                     )
                 )
                 continue
+            if assignee_email not in user_tasks:
+                user_tasks[assignee_email] = []
+            user_tasks[assignee_email].append(task)
+        # Then we send an email to each user with their assigned tasks
+        for assignee_email, tasks in user_tasks.items():
+            email_content = self.presenter.tasks_to_email(tasks)
             await self.email_client.send_email(
                 SendEmailArgs(
-                    recipient=tasks[0].get("assignee_email"),
+                    recipient=assignee_email,
                     subject="[SAVIIA] Summary of your pending tasks",
                     body=email_content,
                     content_type="html",
@@ -165,6 +169,8 @@ class GetPendingTasksUseCase:
                         "priority",
                         "periodicity",
                         "assignee",
+                        "assignee_email",
+                        "description"
                     ],
                 },
             )

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -13,6 +13,7 @@ from saviialib.libs.zero_dependency.utils.datetime_utils import (
     datetime_to_timestamp,
     str_to_datetime,
 )
+from saviialib.libs.email_client import SendEmailArgs
 
 
 class GetPendingTasksUseCase:
@@ -24,6 +25,7 @@ class GetPendingTasksUseCase:
         self.notification_client = input.notification_client
         self.date_format = "%Y-%m-%d"
         self.today = datetime_to_timestamp(today(), self.date_format)
+        self.email_client = input.email_client
 
     def _set_date_state(self, date_tmp: float):
         """If self.today > date_tmp, then the date_tmp is overdue (1). Otherwise, is on-time (0)"""
@@ -118,6 +120,36 @@ class GetPendingTasksUseCase:
             -t["priority"],  # higher numeric priority first
         )
 
+    async def _send_emails_to_assigned_users(self, tasks: list) -> None:
+        # First we group by user and the tasks assigned to them
+        user_tasks = {}
+        for task in tasks:
+            assignee = task["assignee"]
+            if assignee not in user_tasks:
+                user_tasks[assignee] = []
+            user_tasks[assignee].append(task)
+        # Then we send an email to each user with their assigned tasks
+        for user, tasks in user_tasks.items():
+            email_content = self.presenter.tasks_to_email(user, tasks)
+            if not tasks[0].get("assignee_email"):
+                self.logger.debug(
+                    DebugArgs(
+                        LogStatus.EARLY_RETURN,
+                        metadata={
+                            "msg": f"User {user} does not have an email address assigned. Skipping email notification."
+                        },
+                    )
+                )
+                continue
+            await self.email_client.send_email(
+                SendEmailArgs(
+                    recipient=tasks[0].get("assignee_email"),
+                    subject="[SAVIIA] Summary of your pending tasks",
+                    body=email_content,
+                    content_type="html",
+                )
+            )
+
     async def execute(self) -> GetPendingTasksUseCaseOutput:
         self.logger.method_name = "execute"
         self.logger.debug(DebugArgs(LogStatus.STARTED))
@@ -141,6 +173,7 @@ class GetPendingTasksUseCase:
         preprocessed_tasks = self._preprocess_tasks(uncompleted_tasks.tasks)
         sorted_tasks = sorted(preprocessed_tasks, key=self._compare_by_attr)
         overdue, ontime = self._split_task_arrays(sorted_tasks)
+        await self._send_emails_to_assigned_users(uncompleted_tasks.tasks)
 
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
         return GetPendingTasksUseCaseOutput(overdue, ontime)

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -170,7 +170,7 @@ class GetPendingTasksUseCase:
                         "periodicity",
                         "assignee",
                         "assignee_email",
-                        "description"
+                        "description",
                     ],
                 },
             )

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -197,7 +197,14 @@ class GetPendingTasksUseCase:
             await self.dir_client.touch(pass_file_path)
         filename = datetime_to_str(today(), date_format="%Y%m%d") + "_tasks.xlsx"
         df = pd.DataFrame(tasks)
-        df = df.drop(columns=["assignee_email", "periodicity_freq", "periodicity_categ", "deadline_categ"])
+        df = df.drop(
+            columns=[
+                "assignee_email",
+                "periodicity_freq",
+                "periodicity_categ",
+                "deadline_categ",
+            ]
+        )
         excel_file_path = self.dir_client.join_paths(tasks_dir, filename)
         df.to_excel(excel_file_path, index=False)
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))

--- a/src/saviialib/services/tasks/use_cases/get_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_tasks.py
@@ -6,7 +6,7 @@ from saviialib.services.tasks.presenters import TaskNotificationPresenter
 class GetTasksUseCase:
     def __init__(self, input: GetTasksUseCaseInput) -> None:
         self.logger = LogClient(
-            LogClientArgs(service_name="tasks", class_name="update_tasks")
+            LogClientArgs(service_name="tasks", class_name="get_tasks")
         )
         self.params = input.params
         self.notification_client = input.notification_client

--- a/src/saviialib/services/tasks/use_cases/types/create_task_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/create_task_types.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
 from saviialib.services.tasks.entities.task import SaviiaTask
-
+from saviialib.libs.email_client import EmailClient
 
 @dataclass
 class CreateTaskUseCaseInput:
     task: SaviiaTask
     notification_client: NotificationClient
+    email_client: EmailClient
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/types/create_task_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/create_task_types.py
@@ -3,6 +3,7 @@ from saviialib.libs.notification_client import NotificationClient
 from saviialib.services.tasks.entities.task import SaviiaTask
 from saviialib.libs.email_client import EmailClient
 
+
 @dataclass
 class CreateTaskUseCaseInput:
     task: SaviiaTask

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
 from saviialib.libs.email_client import EmailClient
+from saviialib.libs.directory_client import DirectoryClient
 from typing import Dict, List
 
 
@@ -8,6 +9,11 @@ from typing import Dict, List
 class GetPendingTasksUseCaseInput:
     notification_client: NotificationClient
     email_client: EmailClient
+    dir_client: DirectoryClient
+    local_backup_path: str = ""
+    download: bool = False
+    notify: bool = False
+    
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
+from saviialib.libs.email_client import EmailClient
 from typing import Dict, List
 
 
 @dataclass
 class GetPendingTasksUseCaseInput:
     notification_client: NotificationClient
+    email_client: EmailClient
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -13,7 +13,6 @@ class GetPendingTasksUseCaseInput:
     local_backup_path: str = ""
     download: bool = False
     notify: bool = False
-    
 
 
 @dataclass

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -9,6 +9,7 @@ from saviialib.libs.email_client.clients.smtplib_client import SmtpLibClient
 class TestSmtpLibClientSendEmail(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.init_args = EmailClientInitArgs(
+            client_name="smtplib",
             email_address="sender@example.com",
             email_password="secret",
             smtp_server="smtp.gmail.com",
@@ -84,6 +85,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
         self.init_args = EmailClientInitArgs(
             email_address="sender@example.com",
             email_password="secret",
+            client_name="smtplib",
         )
         self.send_args = SendEmailArgs(
             recipient="recipient@example.com",
@@ -117,6 +119,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
     def test_should_use_default_smtp_server_and_port(self):
         # Arrange
         args = EmailClientInitArgs(
+            client_name="smtplib",
             email_address="a@b.com",
             email_password="pw",
         )

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -1,0 +1,129 @@
+import smtplib
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from saviialib.libs.email_client import EmailClient, EmailClientInitArgs, SendEmailArgs
+from saviialib.libs.email_client.clients.smtplib_client import SmtpLibClient
+
+
+class TestSmtpLibClientSendEmail(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.init_args = EmailClientInitArgs(
+            email_address="sender@example.com",
+            email_password="secret",
+            smtp_server="smtp.gmail.com",
+            smtp_port=587,
+        )
+        self.send_args_plain = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Test Subject",
+            body="Hello, world!",
+            content_type="plain",
+        )
+        self.send_args_html = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Test Subject",
+            body="<h1>Hello</h1>",
+            content_type="html",
+        )
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_send_plain_email_successfully(self, mock_smtp_class):
+        # Arrange
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+        client = SmtpLibClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args_plain)
+
+        # Assert
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("sender@example.com", "secret")
+        mock_server.sendmail.assert_called_once()
+        self.assertEqual(result["recipient"], "recipient@example.com")
+        self.assertEqual(result["subject"], "Test Subject")
+        self.assertEqual(result["content_type"], "plain")
+        self.assertEqual(result["status"], "sent")
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_send_html_email_successfully(self, mock_smtp_class):
+        # Arrange
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+        client = SmtpLibClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args_html)
+
+        # Assert
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("sender@example.com", "secret")
+        mock_server.sendmail.assert_called_once()
+        self.assertEqual(result["content_type"], "html")
+        self.assertEqual(result["status"], "sent")
+
+    @patch("saviialib.libs.email_client.clients.smtplib_client.smtplib.SMTP")
+    async def test_should_raise_connection_error_on_smtp_exception(
+        self, mock_smtp_class
+    ):
+        # Arrange
+        mock_smtp_class.side_effect = smtplib.SMTPException("SMTP failure")
+        client = SmtpLibClient(self.init_args)
+
+        # Act & Assert
+        with self.assertRaises(ConnectionError) as context:
+            await client.send_email(self.send_args_plain)
+        self.assertIn("SMTP failure", str(context.exception))
+
+
+class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.init_args = EmailClientInitArgs(
+            email_address="sender@example.com",
+            email_password="secret",
+        )
+        self.send_args = SendEmailArgs(
+            recipient="recipient@example.com",
+            subject="Hello",
+            body="Test body",
+            content_type="plain",
+        )
+
+    @patch(
+        "saviialib.libs.email_client.email_client.SmtpLibClient.send_email",
+        new_callable=AsyncMock,
+    )
+    async def test_should_delegate_send_email_to_smtplib_client(
+        self, mock_send_email
+    ):
+        # Arrange
+        expected = {
+            "recipient": "recipient@example.com",
+            "subject": "Hello",
+            "content_type": "plain",
+            "status": "sent",
+        }
+        mock_send_email.return_value = expected
+        client = EmailClient(self.init_args)
+
+        # Act
+        result = await client.send_email(self.send_args)
+
+        # Assert
+        mock_send_email.assert_called_once_with(self.send_args)
+        self.assertEqual(result, expected)
+
+    def test_should_use_default_smtp_server_and_port(self):
+        # Arrange
+        args = EmailClientInitArgs(
+            email_address="a@b.com",
+            email_password="pw",
+        )
+        # Act
+        client = EmailClient(args)
+        # Assert
+        self.assertEqual(client.client_obj.smtp_server, "smtp.gmail.com")
+        self.assertEqual(client.client_obj.smtp_port, 587)

--- a/tests/saviialib/libs/email_client/test_email_client.py
+++ b/tests/saviialib/libs/email_client/test_email_client.py
@@ -96,9 +96,7 @@ class TestEmailClientSendEmail(unittest.IsolatedAsyncioTestCase):
         "saviialib.libs.email_client.email_client.SmtpLibClient.send_email",
         new_callable=AsyncMock,
     )
-    async def test_should_delegate_send_email_to_smtplib_client(
-        self, mock_send_email
-    ):
+    async def test_should_delegate_send_email_to_smtplib_client(self, mock_send_email):
         # Arrange
         expected = {
             "recipient": "recipient@example.com",

--- a/tests/saviialib/services/thies/test_thies_api.py
+++ b/tests/saviialib/services/thies/test_thies_api.py
@@ -19,6 +19,7 @@ class TestEpiiAPIUpdateThiesData(unittest.IsolatedAsyncioTestCase):
             sharepoint_tenant_id="tenant_id_123",
             sharepoint_tenant_name="tenant_name_123",
             logger=Mock(),
+            local_backup_path="/share/G"
         )
         self.sharepoint_folders_path = [
             "Shared%20Documents/General/Test_Raspberry/THIES/AVG",

--- a/tests/saviialib/test_saviia_api.py
+++ b/tests/saviialib/test_saviia_api.py
@@ -17,6 +17,7 @@ class TestSaviiaAPI(unittest.TestCase):
             sharepoint_tenant_name="tenant_name_123",
             sharepoint_site_name="site_name_123",
             logger=Mock(),
+            local_backup_path="/share/G"
         )
 
     def test_should_initialize_saviia_api_with_both_services(self):


### PR DESCRIPTION
## Changes

* Added modular `EmailClient` with `SmtpLibClient` and integrated email notifications for task creation and pending summaries.
* Extended configs with `email_address`, `email_password`, and `local_backup_path`.
* Updated controllers and use cases to support email sending, backup, and new flags for pending tasks.
* Added HTML email generation in `TaskNotificationPresenter`.
* Implemented async `touch` method in directory client and contract.

## Checklist before requesting a review

* [x] I have tested my code and it works as expected.
* [x] I have added necessary documentation (if appropriate) in the README.md.
* [x] I applied the linter with `make lint` and fixed any issues.
* [x] I follow the conventional commits and I know that my branch should be named feat(<service>) when adding a new feature, fix(<service>) when fixing a bug, and refactor(<service>) or chore when doing maintenance work.
* [x] I know that before merging, I need pull the latest changes from the main branch and make a release version of saviia-lib with `make release`.
