### PR TITLE
feat(tasks): add email notifications, backup support, and directory touch method

### DIFF
--- a/src/saviialib/__init__.py
+++ b/src/saviialib/__init__.py
@@ -91,6 +91,7 @@ class SaviiaAPI:
                     task_channel_id=config.tasks_channel_id,
                     email_address=config.email_address,
                     email_password=config.email_password,
+                    local_backup_path=config.local_backup_path
                 )
 
             self._instances[name] = api_class(service_config)

--- a/src/saviialib/general_types/api/saviia_api_types.py
+++ b/src/saviialib/general_types/api/saviia_api_types.py
@@ -30,6 +30,7 @@ class SaviiaAPIConfig:
     sharepoint_tenant_name: str
     sharepoint_site_name: str
     logger: Logger
+    local_backup_path: str
     latitude: float = -91
     longitude: float = -181
     tasks_channel_id: str = ""

--- a/src/saviialib/general_types/api/saviia_tasks_api_types.py
+++ b/src/saviialib/general_types/api/saviia_tasks_api_types.py
@@ -15,4 +15,5 @@ class SaviiaTasksConfig:
     task_channel_id: str = ""
     email_address: str = ""
     email_password: str = ""
+    local_backup_path: str = ""
     

--- a/src/saviialib/libs/directory_client/client/os_client.py
+++ b/src/saviialib/libs/directory_client/client/os_client.py
@@ -65,3 +65,11 @@ class OsClient(DirectoryClientContract):
     @staticmethod
     def get_basename(path: str):
         return os.path.basename(path)
+
+    @staticmethod
+    async def touch(path: str):
+        def _touch(path):
+            with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT), "w"):
+                pass
+            os.utime(path, None)
+        await asyncio.to_thread(_touch, path)

--- a/src/saviialib/libs/directory_client/directory_client.py
+++ b/src/saviialib/libs/directory_client/directory_client.py
@@ -30,7 +30,7 @@ class DirectoryClient(DirectoryClientContract):
 
     async def makedirs(self, path: str) -> None:
         return await self.client_obj.makedirs(path)
-    
+
     async def removedirs(self, path: str) -> None:
         return await self.client_obj.removedirs(path)
 
@@ -39,6 +39,9 @@ class DirectoryClient(DirectoryClientContract):
 
     async def walk(self, path: str) -> Iterator:
         return await self.client_obj.walk(path)
+
+    async def touch(self, path: str) -> None:
+        return await self.client_obj.touch(path)
 
     def relative_path(self, full_path: str, base_folder: str):
         return self.client_obj.relative_path(full_path, base_folder)

--- a/src/saviialib/libs/directory_client/directory_client_contract.py
+++ b/src/saviialib/libs/directory_client/directory_client_contract.py
@@ -42,3 +42,7 @@ class DirectoryClientContract(ABC):
     @abstractmethod
     def get_basename(self, path: str):
         pass
+    
+    @abstractmethod
+    async def touch(self, path: str):
+        pass

--- a/src/saviialib/services/tasks/api.py
+++ b/src/saviialib/services/tasks/api.py
@@ -89,7 +89,9 @@ class SaviiaTasksAPI:
         response = await controller.execute()
         return response.__dict__
 
-    async def get_pending_tasks(self, download: bool = False, notify: bool = False) -> Dict[str, Any]:
+    async def get_pending_tasks(
+        self, download: bool = False, notify: bool = False
+    ) -> Dict[str, Any]:
         """
         Retrieves pending tasks organized by deadline status and sorted by priority.
 

--- a/src/saviialib/services/tasks/api.py
+++ b/src/saviialib/services/tasks/api.py
@@ -89,7 +89,7 @@ class SaviiaTasksAPI:
         response = await controller.execute()
         return response.__dict__
 
-    async def get_pending_tasks(self) -> Dict[str, Any]:
+    async def get_pending_tasks(self, download: bool = False, notify: bool = False) -> Dict[str, Any]:
         """
         Retrieves pending tasks organized by deadline status and sorted by priority.
 
@@ -102,7 +102,7 @@ class SaviiaTasksAPI:
         :rtype: Dict[str, Any]
         """
         controller = GetPendingTasksController(
-            GetPendingTasksControllerInput(self.config)
+            GetPendingTasksControllerInput(self.config, download, notify)
         )
         response = await controller.execute()
         return response.__dict__

--- a/src/saviialib/services/tasks/controllers/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/controllers/get_pending_tasks.py
@@ -17,6 +17,7 @@ from .types.get_pending_tasks_types import (
     GetPendingTasksControllerOutput,
 )
 from saviialib.libs.email_client import EmailClient, EmailClientInitArgs
+from saviialib.libs.directory_client import DirectoryClient, DirectoryClientArgs
 
 
 class GetPendingTasksController:
@@ -39,6 +40,7 @@ class GetPendingTasksController:
                 smtp_port=587,
             )
         )
+        self.dir_client = DirectoryClient(DirectoryClientArgs(client_name="os_client"))
 
     async def _connect_clients(self) -> None:
         await self.notification_client.connect()
@@ -52,6 +54,8 @@ class GetPendingTasksController:
                 {
                     "bot_token": self.input.config.bot_token,
                     "task_channel_id": self.input.config.task_channel_id,
+                    "download": self.input.download,
+                    "notify": self.input.notify,
                 }
             )
             await self._connect_clients()
@@ -59,6 +63,10 @@ class GetPendingTasksController:
                 GetPendingTasksUseCaseInput(
                     notification_client=self.notification_client,
                     email_client=self.email_client,
+                    dir_client=self.dir_client,
+                    local_backup_path=self.input.config.local_backup_path,
+                    download=self.input.download,
+                    notify=self.input.notify,
                 )
             )
             output = await use_case.execute()

--- a/src/saviialib/services/tasks/controllers/types/get_pending_tasks_schema.py
+++ b/src/saviialib/services/tasks/controllers/types/get_pending_tasks_schema.py
@@ -5,6 +5,8 @@ GET_PENDING_TASKS_SCHEMA = {
     "properties": {
         "bot_token": {"type": "string"},
         "task_channel_id": {"type": "string"},
+        "download": {"type": "boolean"},
+        "notify": {"type": "boolean"},
     },
     "required": ["bot_token", "task_channel_id"],
     "additionalProperties": False,

--- a/src/saviialib/services/tasks/controllers/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/controllers/types/get_pending_tasks_types.py
@@ -6,6 +6,8 @@ from saviialib.general_types.api.saviia_tasks_api_types import SaviiaTasksConfig
 @dataclass
 class GetPendingTasksControllerInput:
     config: SaviiaTasksConfig
+    download: bool = False
+    notify: bool = False
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -12,11 +12,15 @@ from saviialib.libs.zero_dependency.utils.datetime_utils import (
     today,
     datetime_to_timestamp,
     str_to_datetime,
+    datetime_to_str,
 )
+import pandas as pd
 from saviialib.libs.email_client import SendEmailArgs
 
 
 class GetPendingTasksUseCase:
+    TASKS_DIRNAME = "saviia-tasks"
+
     def __init__(self, input: GetPendingTasksUseCaseInput) -> None:
         self.logger = LogClient(
             LogClientArgs(service_name="tasks", class_name="get_pending_tasks")
@@ -26,6 +30,10 @@ class GetPendingTasksUseCase:
         self.date_format = "%Y-%m-%d"
         self.today = datetime_to_timestamp(today(), self.date_format)
         self.email_client = input.email_client
+        self.local_backup_path = input.local_backup_path
+        self.dir_client = input.dir_client
+        self.download = input.download
+        self.notify = input.notify
 
     def _set_date_state(self, date_tmp: float):
         """If self.today > date_tmp, then the date_tmp is overdue (1). Otherwise, is on-time (0)"""
@@ -65,9 +73,13 @@ class GetPendingTasksUseCase:
             map(
                 lambda t: {
                     "title": t["title"],
+                    "creation": t.get("creation", ""),
                     "deadline": t["deadline"],
+                    "execution": t.get("execution", ""),
+                    "description": t.get("description", ""),
                     "priority": int(t["priority"]),
                     "assignee": t["assignee"],
+                    "assignee_email": t.get("assignee_email", ""),
                     "deadline_categ": self._set_date_state(
                         datetime_to_timestamp(
                             str_to_datetime(t["deadline"], self.date_format),
@@ -154,10 +166,46 @@ class GetPendingTasksUseCase:
                 )
             )
 
+    async def _save_tasks(self, tasks: list[dict[str, str | bool | dict]]) -> None:
+        self.logger.method_name = "_save_tasks"
+        self.logger.debug(DebugArgs(LogStatus.STARTED))
+        if not await self.dir_client.path_exists(self.local_backup_path):
+            self.logger.debug(
+                DebugArgs(
+                    LogStatus.EARLY_RETURN,
+                    metadata={
+                        "msg": f"The directory {self.local_backup_path} doesn't exist."
+                    },
+                )
+            )
+            return
+        # First time access
+        tasks_dir = self.dir_client.join_paths(
+            self.local_backup_path, self.TASKS_DIRNAME
+        )
+        if not await self.dir_client.path_exists(tasks_dir):
+            self.logger.debug(
+                DebugArgs(
+                    LogStatus.ALERT,
+                    metadata={
+                        "msg": f"The directory {self.TASKS_DIRNAME} doesn't exist. Creating..."
+                    },
+                )
+            )
+            await self.dir_client.makedirs(tasks_dir)
+            pass_file_path = self.dir_client.join_paths(tasks_dir, ".PASS.txt")
+            await self.dir_client.touch(pass_file_path)
+        filename = datetime_to_str(today(), date_format="%Y%m%d") + "_tasks.xlsx"
+        df = pd.DataFrame(tasks)
+        df = df.drop(columns=["assignee_email", "periodicity_freq", "periodicity_categ", "deadline_categ"])
+        excel_file_path = self.dir_client.join_paths(tasks_dir, filename)
+        df.to_excel(excel_file_path, index=False)
+        self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
+        self.logger.method_name = "execute"
+
     async def execute(self) -> GetPendingTasksUseCaseOutput:
         self.logger.method_name = "execute"
         self.logger.debug(DebugArgs(LogStatus.STARTED))
-
         uncompleted_tasks = await GetTasksUseCase(
             GetTasksUseCaseInput(
                 self.notification_client,
@@ -165,7 +213,9 @@ class GetPendingTasksUseCase:
                     "completed": False,
                     "fields": [
                         "title",
+                        "creation",
                         "deadline",
+                        "execution",
                         "priority",
                         "periodicity",
                         "assignee",
@@ -175,11 +225,22 @@ class GetPendingTasksUseCase:
                 },
             )
         ).execute()
-
         preprocessed_tasks = self._preprocess_tasks(uncompleted_tasks.tasks)
         sorted_tasks = sorted(preprocessed_tasks, key=self._compare_by_attr)
         overdue, ontime = self._split_task_arrays(sorted_tasks)
-        await self._send_emails_to_assigned_users(uncompleted_tasks.tasks)
+        self.logger.debug(
+            DebugArgs(LogStatus.ALERT, {"msg": f"send email?: {self.notify}"})
+        )
+        if self.notify:
+            await self._send_emails_to_assigned_users(sorted_tasks)
+        self.logger.debug(
+            DebugArgs(
+                LogStatus.ALERT,
+                {"msg": f"download not completed tasks?: {self.download}"},
+            )
+        )
+        if self.download:
+            await self._save_tasks(sorted_tasks)
 
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))
         return GetPendingTasksUseCaseOutput(overdue, ontime)

--- a/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_pending_tasks.py
@@ -197,7 +197,14 @@ class GetPendingTasksUseCase:
             await self.dir_client.touch(pass_file_path)
         filename = datetime_to_str(today(), date_format="%Y%m%d") + "_tasks.xlsx"
         df = pd.DataFrame(tasks)
-        df = df.drop(columns=["assignee_email", "periodicity_freq", "periodicity_categ", "deadline_categ"])
+        df = df.drop(
+            columns=[
+                "assignee_email",
+                "periodicity_freq",
+                "periodicity_categ",
+                "deadline_categ",
+            ]
+        )
         excel_file_path = self.dir_client.join_paths(tasks_dir, filename)
         df.to_excel(excel_file_path, index=False)
         self.logger.debug(DebugArgs(LogStatus.SUCCESSFUL))

--- a/src/saviialib/services/tasks/use_cases/get_tasks.py
+++ b/src/saviialib/services/tasks/use_cases/get_tasks.py
@@ -6,7 +6,7 @@ from saviialib.services.tasks.presenters import TaskNotificationPresenter
 class GetTasksUseCase:
     def __init__(self, input: GetTasksUseCaseInput) -> None:
         self.logger = LogClient(
-            LogClientArgs(service_name="tasks", class_name="update_tasks")
+            LogClientArgs(service_name="tasks", class_name="get_tasks")
         )
         self.params = input.params
         self.notification_client = input.notification_client

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from saviialib.libs.notification_client import NotificationClient
 from saviialib.libs.email_client import EmailClient
+from saviialib.libs.directory_client import DirectoryClient
 from typing import Dict, List
 
 
@@ -8,6 +9,11 @@ from typing import Dict, List
 class GetPendingTasksUseCaseInput:
     notification_client: NotificationClient
     email_client: EmailClient
+    dir_client: DirectoryClient
+    local_backup_path: str = ""
+    download: bool = False
+    notify: bool = False
+    
 
 
 @dataclass

--- a/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
+++ b/src/saviialib/services/tasks/use_cases/types/get_pending_tasks_types.py
@@ -13,7 +13,6 @@ class GetPendingTasksUseCaseInput:
     local_backup_path: str = ""
     download: bool = False
     notify: bool = False
-    
 
 
 @dataclass

--- a/tests/saviialib/services/thies/test_thies_api.py
+++ b/tests/saviialib/services/thies/test_thies_api.py
@@ -19,6 +19,7 @@ class TestEpiiAPIUpdateThiesData(unittest.IsolatedAsyncioTestCase):
             sharepoint_tenant_id="tenant_id_123",
             sharepoint_tenant_name="tenant_name_123",
             logger=Mock(),
+            local_backup_path="/share/G"
         )
         self.sharepoint_folders_path = [
             "Shared%20Documents/General/Test_Raspberry/THIES/AVG",

--- a/tests/saviialib/test_saviia_api.py
+++ b/tests/saviialib/test_saviia_api.py
@@ -17,6 +17,7 @@ class TestSaviiaAPI(unittest.TestCase):
             sharepoint_tenant_name="tenant_name_123",
             sharepoint_site_name="site_name_123",
             logger=Mock(),
+            local_backup_path="/share/G"
         )
 
     def test_should_initialize_saviia_api_with_both_services(self):


### PR DESCRIPTION
## Changes

* Added modular `EmailClient` with `SmtpLibClient` and integrated email notifications for task creation and pending summaries.
* Extended configs with `email_address`, `email_password`, and `local_backup_path`.
* Updated controllers and use cases to support email sending, backup, and new flags for pending tasks.
* Added HTML email generation in `TaskNotificationPresenter`.
* Implemented async `touch` method in directory client and contract.

## Checklist before requesting a review

* [x] I have tested my code and it works as expected.
* [x] I have added necessary documentation (if appropriate) in the README.md.
* [x] I applied the linter with `make lint` and fixed any issues.
* [x] I follow the conventional commits and I know that my branch should be named feat(<service>) when adding a new feature, fix(<service>) when fixing a bug, and refactor(<service>) or chore when doing maintenance work.
* [x] I know that before merging, I need pull the latest changes from the main branch and make a release version of saviia-lib with `make release`.
