### PR TITLE
fix(tasks): improve notification parsing in TaskNotificationPresenter

### DIFF
--- a/src/saviialib/services/tasks/presenters/task_notification_presenter.py
+++ b/src/saviialib/services/tasks/presenters/task_notification_presenter.py
@@ -7,33 +7,56 @@ from saviialib.libs.zero_dependency.utils.datetime_utils import (
 class TaskNotificationPresenter:
     @classmethod
     def to_dict(cls, content: str) -> dict[str, str]:
-        lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+        lines = [line.rstrip() for line in content.strip().splitlines()]
         result = {}
-        result["title"] = lines[0].lstrip("#").strip()
-        for line in lines[2:]:
+        current_field = None
+
+        for index, raw_line in enumerate(lines):
+            line = raw_line.strip()
+
+            if not line:
+                continue
+
+            if index == 0 and line.startswith("#"):
+                result["title"] = line.lstrip("#").strip()
+                continue
+
             if "__Estado__" in line:
-                status = line.split(":")[1].strip()
+                status = line.split(":", 1)[1].strip()
                 result["completed"] = False if "Pendiente" in status else True
+                current_field = None
             elif "__Fecha limite__" in line:
-                result["deadline"] = line.split(":")[1].strip()
+                result["deadline"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Fecha creación__" in line:
-                result["creation"] = line.split(":")[1].strip()
+                result["creation"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Fecha de ejecución__" in line:
-                result["execution"] = line.split(":")[1].strip()
+                result["execution"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Descripcion__" in line:
-                result["description"] = line.split(":")[1].strip()
+                result["description"] = line.split(":", 1)[1].strip()
+                current_field = "description"
             elif "__Periodicidad__" in line:
-                result["periodicity"] = line.split(":")[1].strip()
+                result["periodicity"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Prioridad__" in line:
-                result["priority"] = line.split(":")[1].strip()
+                result["priority"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Categoría__" in line:
-                result["category"] = line.split(":")[1].strip()
+                result["category"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Persona asignada__" in line:
-                result["assignee"] = line.split(":")[1].strip()
+                result["assignee"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Email de la persona asignada__" in line:
-                result["assignee_email"] = line.split(":")[1].strip()
+                result["assignee_email"] = line.split(":", 1)[1].strip()
+                current_field = None
             elif "__Discord username de la persona asignada__" in line:
-                result["assignee_discord_username"] = line.split(":")[1].strip()
+                result["assignee_discord_username"] = line.split(":", 1)[1].strip()
+                current_field = None
+            elif current_field == "description":
+                result["description"] = f"{result.get('description', '')}\n{line}".strip()
         return result
 
     @classmethod


### PR DESCRIPTION
## Changes

* Refactored `TaskNotificationPresenter.to_dict` to improve robustness and readability of notification parsing.
* Replaced line splitting with `splitlines()` and `rstrip()` to better handle different newline formats while preserving relevant whitespace.
* Updated field parsing to split only on the first colon (`split(":", 1)`), ensuring values containing colons are handled correctly.
* Added support for multi-line descriptions by tracking the description context and appending subsequent lines properly.
* Simplified and clarified parsing logic using indexed iteration and explicit field handling.
* Standardized whitespace trimming across all parsed fields for consistency.

## Checklist before requesting a review

* [x] I have tested my code and it works as expected.
* [x] I have added necessary documentation (if appropriate) in the README.md.
* [x] I applied the linter with `make lint` and fixed any issues.
* [x] I follow the conventional commits and I know that my branch should be named feat(<service>) when adding a new feature, fix(<service>) when fixing a bug, and refactor(<service>) or chore when doing maintenance work.
* [x] I know that before merging, I need pull the latest changes from the main branch and make a release version of saviia-lib with `make release`.
